### PR TITLE
增加一个参数配置，configPatch,改参数接受最终的config参数，支持开发者做自定义的修改，然后返回修改后的webpack配置

### DIFF
--- a/__tests__/webpack.config.js
+++ b/__tests__/webpack.config.js
@@ -69,4 +69,16 @@ describe("带参数初始化配置", () => {
         expect(spy).toBeCalledWith(expect.any(Array));
         expect(config.module.rules === newRules).toBe(true);
     })
+
+    it("如果提供了configPatch，那么该参数是一个函数，并且该函数应该会被调用，同时参数是一个对象，返回值也是一个对象",()=>{
+        const spy = jest.fn();
+        const newConfig = {};
+        spy.mockReturnValue(newConfig)
+        const config = webpackConfig({
+            configPatch: spy
+        })
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toBeCalledWith(expect.any(Object));
+        expect(config === newConfig).toBe(true);
+    })
 });

--- a/helpers/parse-config.js
+++ b/helpers/parse-config.js
@@ -85,7 +85,9 @@ module.exports = options => {
         //支持的视图库
         engines: options.engines || defaultEngines,
         // js ts mixed //使用开发语言，js或者ts，或者混着用
-        language: options.language || languageJs
+        language: options.language || languageJs,
+        //外部传入的方法，接受参数是最终的webpack配置对象，自定义修改后需要接着返回
+        configPatch: options.configPatch
     };
     return config;
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,8 @@ module.exports = (options = {}) => {
         friendly,
         moduleScope,
         dllList,
-        outputUseHash
+        outputUseHash,
+        configPatch
     } = (global[globalObjectKey] = o = require("./helpers/parse-config")(
         options
     ));
@@ -49,7 +50,7 @@ module.exports = (options = {}) => {
         rules = applyRules(rules)
     }
 
-    return {
+    const rawConfig = {
         context: moduleScope,
         entry: o.entry,
         output: {
@@ -87,4 +88,6 @@ module.exports = (options = {}) => {
         target: "web",
         devtool: buildProd ? "cheap-source-map" : false
     };
+    if(typeof(configPatch) === typeFunc) return configPatch(rawConfig);
+    return rawConfig;
 };


### PR DESCRIPTION
例如：
```
module.exports = require("@talentui/webpack-config")({
	configPatch: function(config) {
		return Object.assign({}, config, {
				node:{
					fs: 'empty'
				}
		})
	}
})
```