### PR TITLE
chore(loader): cache loader 发布的1.2.4版本有bug，导致咱们的构建出问题。先锁死版本

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "add-asset-html-webpack-plugin": "^2.1.3",
     "babel-eslint": "^7.2.3",
     "babel-loader": "^8.0.0",
-    "cache-loader": "^1.2.2",
+    "cache-loader": "1.2.2",
     "case-sensitive-paths-webpack-plugin": "^2.1.2",
     "chalk": "^2.4.1",
     "clean-webpack-plugin": "^0.1.19",


### PR DESCRIPTION
已经给官方提了issue https://github.com/webpack-contrib/cache-loader/issues/46